### PR TITLE
为歌单添加刷新按钮

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -40,6 +40,8 @@ pub(crate) enum Action {
     MineHideAll,
     MineShowFm,
     RefreshMineViewInit(i32),
+    RefreshMineCurrentView(),
+    RefreshMineLikeList(),
     RefreshMineView(Vec<SongInfo>, String),
     RefreshMineFm(SongInfo),
     RefreshMineSidebar(Vec<SongList>),
@@ -181,7 +183,9 @@ impl App {
             Action::RefreshMine => self.view.mine_init(),
             Action::MineHideAll => self.view.mine_hide_all(),
             Action::MineShowFm => self.view.mine_show_fm(),
-            Action::RefreshMineViewInit(id) => self.view.update_mine_view_data(id),
+            Action::RefreshMineViewInit(id) => self.view.update_mine_view_data(id, false),
+            Action::RefreshMineCurrentView() => self.view.update_mine_current_view_data(),
+            Action::RefreshMineLikeList() => self.view.update_like_song_list(),
             Action::RefreshMineView(song_list, title) => {
                 self.view.update_mine_view(song_list, title)
             }

--- a/src/view/mine.rs
+++ b/src/view/mine.rs
@@ -32,6 +32,7 @@ struct UpView {
     container: Grid,
     dislike: Button,
     play: Button,
+    refresh: Button,
     title: Label,
     number: Label,
 }
@@ -110,12 +111,16 @@ impl Mine {
         let dislike: Button = builder
             .get_object("mine_up_del_button")
             .expect("无法获取 mine_up_del_button .");
+        let refresh: Button = builder
+            .get_object("mine_up_refresh_button")
+            .expect("无法获取 mine_up_refresh_button .");
         let upview = UpView {
             container,
             title,
             number,
             dislike,
             play,
+            refresh,
         };
         let container: ScrolledWindow = builder
             .get_object("mine_low_view")
@@ -241,6 +246,14 @@ impl Mine {
         let sender = s.sender.clone();
         s.upview.dislike.connect_clicked(move |_| {
             sender.send(Action::DisLikeSongList).unwrap_or(());
+        });
+
+        // 刷新歌单
+        let sender = s.sender.clone();
+        s.upview.refresh.connect_clicked(move |_| {
+            sender
+                .send(Action::RefreshMineCurrentView())
+                .unwrap_or(());
         });
 
         let sender = s.sender.clone();

--- a/src/widgets/player.rs
+++ b/src/widgets/player.rs
@@ -419,6 +419,9 @@ impl PlayerWidget {
                             sender
                                 .send(Action::ShowNotice("已添加到喜欢!".to_owned()))
                                 .unwrap();
+                            sender
+                                .send(Action::RefreshMineLikeList())
+                                .unwrap();
                         } else {
                             sender
                                 .send(Action::ShowNotice("收藏失败!".to_owned()))

--- a/ui/window.ui
+++ b/ui/window.ui
@@ -507,6 +507,12 @@
     <property name="icon_name">media-playback-start-symbolic</property>
     <property name="icon_size">1</property>
   </object>
+  <object class="GtkImage" id="refresh_list_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">view-refresh-symbolic</property>
+    <property name="icon_size">1</property>
+  </object>
   <object class="GtkStack" id="stack_mine">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -823,6 +829,28 @@
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                    <property name="height">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="mine_up_refresh_button">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="tooltip_text" translatable="yes">刷新歌单</property>
+                    <property name="halign">end</property>
+                    <property name="valign">center</property>
+                    <property name="margin_left">9</property>
+                    <property name="image">refresh_list_image</property>
+                    <property name="always_show_image">True</property>
+                    <style>
+                      <class name="image-button"/>
+                      <class name="circular"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="left_attach">3</property>
                     <property name="top_attach">0</property>
                     <property name="height">2</property>
                   </packing>


### PR DESCRIPTION
每个帐号的 “最喜欢的音乐” 歌单 songlist_id 是不一样的，导致判断刷新机制会失效。
或许添加刷新按钮让用户手动刷新会好一点。