### PR TITLE
使用 pixbuf 处理图片，减少缓存图片冗余数量

### DIFF
--- a/src/view/home.rs
+++ b/src/view/home.rs
@@ -10,6 +10,8 @@ use crate::CACHED_PATH;
 use crossbeam_channel::Sender;
 use gtk::prelude::*;
 use gtk::{Builder, EventBox, Grid, Image, Label};
+use gdk_pixbuf::Pixbuf;
+use gdk_pixbuf::InterpType;
 use rayon::prelude::*;
 
 #[derive(Clone)]
@@ -66,7 +68,7 @@ impl Home {
             let mut t = 0;
             tsl.par_iter().for_each(|sl| {
                 let image_path = format!("{}/{}.jpg", CACHED_PATH.to_owned(), &sl.id);
-                crate::utils::download_img(&sl.cover_img_url, &image_path, 140, 140);
+                crate::utils::download_img(&sl.cover_img_url, &image_path, 512, 512);
             });
             tsl.iter().for_each(|sl| {
                 let event_box = EventBox::new();
@@ -77,9 +79,11 @@ impl Home {
                 label.set_ellipsize(pango::EllipsizeMode::End);
                 label.set_line_wrap(true);
                 let image_path = format!("{}/{}.jpg", CACHED_PATH.to_owned(), &sl.id);
-                let image = Image::new_from_file(&image_path);
-
-                boxs.add(&image);
+                if let Ok(image) = Pixbuf::new_from_file(&image_path) {
+                    let image = image.scale_simple(140, 140, InterpType::Bilinear);
+                    let image = Image::new_from_pixbuf(image.as_ref());
+                    boxs.add(&image);
+                };
                 boxs.add(&label);
                 event_box.add(&boxs);
                 self.up_grid.attach(&event_box, l, t, 1, 1);
@@ -106,7 +110,7 @@ impl Home {
             if !rr.is_empty() {
                 rr.par_iter().for_each(|sl| {
                     let image_path = format!("{}/{}.jpg", CACHED_PATH.to_owned(), &sl.id);
-                    crate::utils::download_img(&sl.cover_img_url, &image_path, 140, 140);
+                    crate::utils::download_img(&sl.cover_img_url, &image_path, 512, 512);
                 });
                 let mut l = 0;
                 for sl in rr.iter() {
@@ -119,9 +123,11 @@ impl Home {
                         label.set_ellipsize(pango::EllipsizeMode::End);
                         label.set_line_wrap(true);
                         let image_path = format!("{}/{}.jpg", CACHED_PATH.to_owned(), &sl.id);
-                        let image = Image::new_from_file(&image_path);
-
-                        boxs.add(&image);
+                        if let Ok(image) = Pixbuf::new_from_file(&image_path) {
+                            let image = image.scale_simple(140, 140, InterpType::Bilinear);
+                            let image = Image::new_from_pixbuf(image.as_ref());
+                            boxs.add(&image);
+                        };
                         boxs.add(&label);
                         event_box.add(&boxs);
 

--- a/src/view/mine.rs
+++ b/src/view/mine.rs
@@ -14,6 +14,7 @@ use gtk::{
     Builder, Button, CellRendererText, Grid, Image, Label, ListBox, ListBoxRow, ListStore, Menu,
     MenuItem, ScrolledWindow, TreeView, TreeViewColumn,
 };
+use gdk_pixbuf::InterpType;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -323,13 +324,14 @@ impl Mine {
     }
 
     pub(crate) fn update_fm_view(&self, song_info: &SongInfo) {
-        let mut image_path = format!(
-            "{}/{}_p210.jpg",
+        let image_path = format!(
+            "{}/{}.jpg",
             crate::CACHED_PATH.to_owned(),
             &song_info.id
         );
-        download_img(&song_info.pic_url, &image_path, 210, 210);
-        let path = format!("{}/{}_p210", crate::CACHED_PATH.to_owned(), &song_info.id);
+        download_img(&song_info.pic_url, &image_path, 512, 512);
+        // let path = format!("{}/{}_p210", crate::CACHED_PATH.to_owned(), &song_info.id);
+        /*
         if create_round_avatar(path).is_ok() {
             image_path = format!(
                 "{}/{}_p210.png",
@@ -337,7 +339,11 @@ impl Mine {
                 &song_info.id
             );
         }
-        self.fmview.image.set_from_file(image_path);
+        */
+        if let Ok(image) = create_round_avatar(image_path) {
+            let image = image.scale_simple(210, 210, InterpType::Bilinear);
+            self.fmview.image.set_from_pixbuf(image.as_ref());
+        }
         self.fmview.title.set_text(&song_info.name);
         self.fmview.singer.set_text(&song_info.singer);
     }

--- a/src/widgets/header.rs
+++ b/src/widgets/header.rs
@@ -347,18 +347,9 @@ impl Header {
         self.popover_user.show_all();
         let image_url = format!("{}?param=37y37", &login_info.avatar_url);
         let image_path = format!("{}/{}.jpg", CACHED_PATH.to_owned(), &login_info.uid);
-        let png_path = format!("{}/{}.png", CACHED_PATH.to_owned(), &login_info.uid);
         download_img(&image_url, &image_path, 37, 37);
-        if std::path::Path::new(&png_path).exists() {
-            self.avatar.set_from_file(&png_path);
-        } else {
-            if create_round_avatar(format!("{}/{}", CACHED_PATH.to_owned(), &login_info.uid))
-                .is_ok()
-            {
-                self.avatar.set_from_file(&png_path);
-            } else {
-                self.avatar.set_from_file(&image_path);
-            }
+        if let Ok(image) = create_round_avatar(image_path) {
+            self.avatar.set_from_pixbuf(Some(&image));
         }
         self.username.set_text(&login_info.nickname);
         self.login.hide();

--- a/src/widgets/player.rs
+++ b/src/widgets/player.rs
@@ -8,6 +8,7 @@ use crate::clone;
 use crate::data::MusicData;
 use crate::musicapi::model::SongInfo;
 use crate::utils::*;
+use crate::CACHED_PATH;
 use chrono::NaiveTime;
 use crossbeam_channel::Sender;
 use fragile::Fragile;
@@ -52,7 +53,8 @@ impl PlayerInfo {
         let mut metadata = Metadata::new();
         metadata.artist = Some(vec![song_info.singer.clone()]);
         metadata.title = Some(song_info.name.clone());
-        metadata.art_url = Some(song_info.pic_url.clone());
+        // metadata.art_url = Some(song_info.pic_url.clone());
+        metadata.art_url = Some(format!("file://{}/{}_p210.jpg", CACHED_PATH.to_owned(), song_info.id));
         metadata.track_number = Some(song_info.id as i32);
 
         self.mpris.set_metadata(metadata);

--- a/src/widgets/player.rs
+++ b/src/widgets/player.rs
@@ -16,6 +16,8 @@ use glib::{SignalHandlerId, WeakRef};
 use gst::ClockTime;
 use gtk::prelude::*;
 use gtk::{ActionBar, Builder, Button, Image, Label, RadioButton, Scale};
+use gdk_pixbuf::Pixbuf;
+use gdk_pixbuf::InterpType;
 use mpris_player::{Metadata, MprisPlayer, OrgMprisMediaPlayer2Player, PlaybackStatus};
 use std::cell::RefCell;
 use std::ops::Deref;
@@ -46,15 +48,18 @@ impl PlayerInfo {
         self.song.set_tooltip_text(Some(&song_info.name[..]));
         self.singer.set_text(&song_info.singer);
         let image_path = format!("{}/{}.jpg", crate::CACHED_PATH.to_owned(), &song_info.id);
-        download_img(&song_info.pic_url, &image_path, 38, 38);
-        self.cover.set_from_file(&image_path);
+        download_img(&song_info.pic_url, &image_path, 512, 512);
+        if let Ok(image) = Pixbuf::new_from_file(&image_path) {
+            let image = image.scale_simple(38, 38, InterpType::Bilinear);
+            self.cover.set_from_pixbuf(image.as_ref());
+        };
         self.cover.set_tooltip_text(Some(&song_info.name[..]));
 
         let mut metadata = Metadata::new();
         metadata.artist = Some(vec![song_info.singer.clone()]);
         metadata.title = Some(song_info.name.clone());
         // metadata.art_url = Some(song_info.pic_url.clone());
-        metadata.art_url = Some(format!("file://{}/{}_p210.jpg", CACHED_PATH.to_owned(), song_info.id));
+        metadata.art_url = Some(format!("file://{}/{}.jpg", CACHED_PATH.to_owned(), song_info.id));
         metadata.track_number = Some(song_info.id as i32);
 
         self.mpris.set_metadata(metadata);


### PR DESCRIPTION
gnome 自带的 mpris 好像不能显示网络图片😓，改成本地文件就能正常显示了。。