### PR TITLE
解决下载音乐时中途退出导致音乐文件不完整的问题

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -37,7 +37,9 @@ where
         let client = HttpClient::builder().timeout(Duration::from_millis(timeout)).build()?;
         let mut response = client.get_async(music_url).await?;
         if response.status().is_success() {
-            response.copy_to_file(path)?;
+            let tmp_path = format!("{}.tmp", path);
+            response.copy_to_file(&tmp_path)?;
+            fs::rename(&tmp_path, path).await?;
         }
     }
     Ok(())


### PR DESCRIPTION
先将文件缓存到一个临时文件里，下载完成之后再重命名

相关issue:  #70