### PR TITLE
Fix: the failure of like song

### DIFF
--- a/src/musicapi/mod.rs
+++ b/src/musicapi/mod.rs
@@ -104,7 +104,7 @@ impl MusicApi {
                 };
 
                 let request = Request::post(&url)
-                    .header("Cookie", "os=pc")
+                    .header("Cookie", "os=pc; appver=2.7.1.198277")
                     .header("Accept", "*/*")
                     .header("Accept-Encoding", "gzip,deflate,br")
                     .header("Accept-Language", "en-US,en;q=0.5")


### PR DESCRIPTION
参考 [Binaryify/NeteaseCloudMusicApi](https://github.com/Binaryify/NeteaseCloudMusicApi/commit/d1907ae541ae991e97dfa93a06227d3d28dac976) 解决了歌曲收藏失败的问题。 #114 