### PR TITLE
使 .desktop 进入正确的分类

### DIFF
--- a/data/com.gitee.gmg137.NeteaseCloudMusicGtk4.desktop.in
+++ b/data/com.gitee.gmg137.NeteaseCloudMusicGtk4.desktop.in
@@ -9,5 +9,5 @@ Exec=netease-cloud-music-gtk4
 Icon=com.gitee.gmg137.NeteaseCloudMusicGtk4
 Terminal=false
 Type=Application
-Categories=GTK;
+Categories=GTK;Audio;AudioVideo
 StartupNotify=true


### PR DESCRIPTION
在 KDE 的 Application Launcher 无法分类，会进入 Lost & Found ，故试图通过修改 Categories 来解决这个问题。