### PR TITLE
use paru to install from AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ sudo zypper in netease-cloud-music-gtk
 
 ### Arch Linux
 ```bash
+# AUR
+paru -S netease-cloud-music-gtk4
+# archlinuxcn repo
 sudo pacman -Syu netease-cloud-music-gtk4
 ```
 


### PR DESCRIPTION
netease-cloud-music-gtk4 is not in Arch Linux's official repos. Arch Linux users might want to install it from AUR