### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /build
 **/*.rs.bk
 /src/config.rs
-/Cargo.lock


### PR DESCRIPTION
添加对Cargo.lock文件的追踪，保证发布安装依赖时版本稳定