### PR TITLE
添加歌词随播放滚动功能

### DIFF
--- a/data/gtk/playlist-lyrics-page.ui
+++ b/data/gtk/playlist-lyrics-page.ui
@@ -14,7 +14,7 @@
                     </object>
                 </property>
                 <property name="flap">
-                    <object class="GtkScrolledWindow">
+                    <object class="GtkScrolledWindow" id="scroll_lyrics_win">
                         <property name="width-request">500</property>
                         <child>
                             <object class="GtkViewport">

--- a/src/gui/playlist_lyrics.rs
+++ b/src/gui/playlist_lyrics.rs
@@ -51,11 +51,52 @@ impl PlayListLyricsPage {
         let songs_list = imp.songs_list.get();
         songs_list.clear_list();
         self.update_playlist(sis, si, likes);
+        self.update_font_size();
+        self.setup_scroll_controller();
 
         let lyrics_text_view = imp.lyrics_text_view.get();
         let buffer = lyrics_text_view.buffer();
         buffer.set_text(&gettext("Loading lyrics..."));
         lyrics_text_view.set_buffer(Some(&buffer));
+    }
+
+    fn setup_scroll_controller(&self) {
+        let scroll_win = self.imp().scroll_lyrics_win.get();
+        let scrolled = self.imp().scrolled.clone();
+
+        let scroll_controller = EventControllerScroll::new(EventControllerScrollFlags::VERTICAL);
+        scroll_controller.connect_scroll(move |_, _, _| {
+            {
+                let mut val = scrolled.lock().unwrap();
+                *val += 1;
+            }
+            let scrolled = scrolled.clone();
+            glib::timeout_add_seconds(3, move || {
+                let mut val = scrolled.lock().unwrap();
+                *val -= 1;
+                glib::ControlFlow::Break
+            });
+            glib::Propagation::Proceed
+        });
+        scroll_win.add_controller(scroll_controller);
+    }
+
+    fn update_font_size(&self) {
+        let imp = self.imp();
+        let lyrics_text_view = imp.lyrics_text_view.get();
+        let pango_context = lyrics_text_view.pango_context();
+        let font_description = pango_context
+            .font_description()
+            .expect("expect font description");
+        let font_size = font_description.size();
+
+        let font_size_in_pixels = if font_description.is_size_absolute() {
+            font_size as f64 / pango::SCALE as f64
+        } else {
+            font_size as f64 / pango::SCALE as f64
+        };
+
+        imp.font_size.replace(font_size_in_pixels);
     }
 
     pub fn update_playlist(&self, sis: &[SongInfo], current_song: SongInfo, likes: &[bool]) {
@@ -85,13 +126,23 @@ impl PlayListLyricsPage {
         lyrics.push((3600000000, "".to_string()));
         lyrics.push((3600000000, "".to_string()));
         let lyrics_text_view = self.imp().lyrics_text_view.get();
+        let scroll_win = self.imp().scroll_lyrics_win.get();
+        let adjustment = scroll_win.vadjustment();
+        let height = scroll_win.allocated_height();
+
+        // the default value of line-height is normal, so the line-height in pixel is
+        // font-size * 1.2(normal)
+        let line_height = self.imp().font_size.get() * 1.2;
+
         let buffer = lyrics_text_view.buffer();
         buffer.set_text("");
         let mut iter = buffer.start_iter();
-        for lyr in lyrics.windows(3) {
+        let mut playing_index = 0;
+        for (i, lyr) in lyrics.windows(3).enumerate() {
             if (time >= lyr[0].0 && time < lyr[1].0)
                 || lyr[0].0 == lyr[1].0 && time >= lyr[0].0 && time < lyr[2].0
             {
+                playing_index = i;
                 buffer.insert_markup(
                     &mut iter,
                     &format!(
@@ -102,6 +153,11 @@ impl PlayListLyricsPage {
             } else {
                 buffer.insert(&mut iter, &lyr[0].1);
             }
+        }
+        if *(self.imp().scrolled.lock().unwrap()) == 0 {
+            let offset =
+                line_height * playing_index as f64 - height as f64 / 2.0 - line_height / 2.0;
+            adjustment.set_value(offset);
         }
     }
 
@@ -118,6 +174,11 @@ impl Default for PlayListLyricsPage {
 
 mod imp {
 
+    use std::{
+        cell::Cell,
+        sync::{Arc, Mutex},
+    };
+
     use super::*;
 
     #[derive(Debug, Default, CompositeTemplate)]
@@ -126,7 +187,11 @@ mod imp {
         #[template_child]
         pub songs_list: TemplateChild<SongListView>,
         #[template_child]
+        pub scroll_lyrics_win: TemplateChild<ScrolledWindow>,
+        #[template_child]
         pub lyrics_text_view: TemplateChild<TextView>,
+        pub(crate) font_size: Cell<f64>,
+        pub(crate) scrolled: Arc<Mutex<usize>>,
         pub playlist: Rc<RefCell<Vec<SongInfo>>>,
         pub sender: OnceCell<Sender<Action>>,
     }


### PR DESCRIPTION
这个patch计算了当前正在播放的歌词的offset,通过调整`ScrolledWindow.vadjustment` 居中正在播放的歌词.

由于歌词被自动居中,会导致用户无法滚动歌词.
这个patch的解决方案是,用户可以自由滚动歌词,但当用户停止滚动3秒后,歌词会重新自动居中.

为了实现上述feature,`ScrolledWindow`的`scroll-event`事件将被捕获(在 `setup_scroll_controller()`中),每次滚动会让`PlayListLyricsPage.scrolled`加1, 并在3s的timeout回调中减1,当该值为0的时候才会进入自动居中. 这里采用了类似于
semaphore的思想,这样就能在用户_最后_一次滚动停止3秒后回到自动居中状态.

![Peek 2024-08-22 09-47](https://github.com/user-attachments/assets/dab9563f-8c57-435f-8f46-1ae41986a4bc)

