### PR TITLE
改进歌词滚动功能：利用 TextTag 和 `scroll_to_mark` 高亮和居中当前播放歌词行

### DIFF
--- a/data/gtk/playlist-lyrics-page.ui
+++ b/data/gtk/playlist-lyrics-page.ui
@@ -14,36 +14,32 @@
                     </object>
                 </property>
                 <property name="flap">
-                    <object class="GtkScrolledWindow" id="scroll_lyrics_win">
-                        <property name="width-request">500</property>
+                    <object class="AdwClamp">
+                        <property name="vexpand">true</property>
+                        <property name="hexpand">true</property>
+                        <property name="halign">fill</property>
+                        <property name="margin-top">10</property>
+                        <property name="margin-bottom">10</property>
+                        <property name="margin-start">20</property>
+                        <property name="margin-end">20</property>
+                        <property name="maximum-size">1000</property>
+                        <property name="tightening-threshold">730</property>
                         <child>
-                            <object class="GtkViewport">
+                            <object class="GtkScrolledWindow" id="scroll_lyrics_win">
+                                <property name="width-request">500</property>
                                 <child>
-                                    <object class="AdwClamp">
-                                        <property name="vexpand">true</property>
-                                        <property name="hexpand">true</property>
-                                        <property name="halign">fill</property>
-                                        <property name="margin-top">10</property>
-                                        <property name="margin-bottom">10</property>
-                                        <property name="margin-start">20</property>
-                                        <property name="margin-end">20</property>
-                                        <property name="maximum-size">1000</property>
-                                        <property name="tightening-threshold">730</property>
-                                        <child>
-                                            <object class="GtkTextView" id="lyrics_text_view">
-                                                <property name="hscroll-policy">natural</property>
-                                                <property name="vscroll-policy">natural</property>
-                                                <property name="pixels-below-lines">1</property>
-                                                <property name="editable">False</property>
-                                                <property name="justification">center</property>
-                                                <property name="left-margin">8</property>
-                                                <property name="right-margin">8</property>
-                                                <property name="top-margin">18</property>
-                                                <property name="bottom_margin">18</property>
-                                                <property name="cursor-visible">False</property>
-                                                <property name="accepts-tab">False</property>
-                                            </object>
-                                        </child>
+                                    <object class="GtkTextView" id="lyrics_text_view">
+                                        <property name="hscroll-policy">natural</property>
+                                        <property name="vscroll-policy">natural</property>
+                                        <property name="pixels-below-lines">1</property>
+                                        <property name="editable">False</property>
+                                        <property name="justification">center</property>
+                                        <property name="left-margin">8</property>
+                                        <property name="right-margin">8</property>
+                                        <property name="top-margin">18</property>
+                                        <property name="bottom_margin">18</property>
+                                        <property name="cursor-visible">False</property>
+                                        <property name="accepts-tab">False</property>
                                     </object>
                                 </child>
                             </object>

--- a/data/gtk/playlist-lyrics-page.ui
+++ b/data/gtk/playlist-lyrics-page.ui
@@ -40,6 +40,22 @@
                                         <property name="bottom_margin">18</property>
                                         <property name="cursor-visible">False</property>
                                         <property name="accepts-tab">False</property>
+                                        <property name="buffer">
+                                            <object class="GtkTextBuffer" id="buffer">
+                                                <property name="tag_table">
+                                                    <object class="GtkTextTagTable">
+                                                        <child type="tag">
+                                                            <object class="GtkTextTag"
+                                                                id="highlight_text_tag">
+                                                                <property name="foreground">red</property>
+                                                                <property name="weight">700</property>
+                                                                <property name="size">13312</property>
+                                                            </object>
+                                                        </child>
+                                                    </object>
+                                                </property>
+                                            </object>
+                                        </property>
                                     </object>
                                 </child>
                             </object>

--- a/src/application.rs
+++ b/src/application.rs
@@ -1167,13 +1167,19 @@ impl NeteaseCloudMusicGtk4Application {
             }
             Action::UpdateLyrics(si, time) => {
                 MAINCONTEXT.spawn_local_with_priority(Priority::DEFAULT_IDLE, async move {
-                    match ncmapi.get_lyrics(si).await {
-                        Ok(lrc) => {
-                            debug!("获取歌词：{:?}", lrc);
-                            window.update_lyrics(lrc, time);
+                    if time == 0 {
+                        // 当新曲目播放时，写入歌词内容
+                        window.update_lyrics_text(&gettext("Loading lyrics..."));
+                        match ncmapi.get_lyrics(si).await {
+                            Ok(lrc) => {
+                                debug!("获取歌词：{:?}", lrc);
+                                window.update_lyrics(lrc);
+                            }
+                            Err(e) => debug!("{}", e),
                         }
-                        Err(e) => debug!("{}", e),
                     }
+                    // 更新歌词高亮位置
+                    window.update_lyrics_timestamp(time);
                 });
             }
             Action::UpdatePlayListStatus(index) => {

--- a/src/gui/playlist_lyrics.rs
+++ b/src/gui/playlist_lyrics.rs
@@ -157,8 +157,9 @@ impl PlayListLyricsPage {
             }
         }
         if *(self.imp().scrolled.lock().unwrap()) == 0 {
-            let offset =
-                line_height * playing_index as f64 - height as f64 / 2.0 - line_height / 2.0;
+            let offset = line_height * playing_index as f64 - height as f64 / 2.0 - line_height / 2.0
+                    + 18.0 // text top-margin
+                    + 10.0; // text view margin-top
             adjustment.set_value(offset.max(0f64));
         }
     }

--- a/src/gui/playlist_lyrics.rs
+++ b/src/gui/playlist_lyrics.rs
@@ -157,7 +157,7 @@ impl PlayListLyricsPage {
         if *(self.imp().scrolled.lock().unwrap()) == 0 {
             let offset =
                 line_height * playing_index as f64 - height as f64 / 2.0 - line_height / 2.0;
-            adjustment.set_value(offset);
+            adjustment.set_value(offset.max(0f64));
         }
     }
 

--- a/src/gui/playlist_lyrics.rs
+++ b/src/gui/playlist_lyrics.rs
@@ -147,7 +147,7 @@ impl PlayListLyricsPage {
                     &mut iter,
                     &format!(
                         r#"<span size="large" weight="bold" color="red">{}</span>"#,
-                        lyr[0].1
+                        lyr[0].1.replace("&", "&amp;")
                     ),
                 );
             } else {

--- a/src/gui/playlist_lyrics.rs
+++ b/src/gui/playlist_lyrics.rs
@@ -51,7 +51,6 @@ impl PlayListLyricsPage {
         let songs_list = imp.songs_list.get();
         songs_list.clear_list();
         self.update_playlist(sis, si, likes);
-        self.update_font_size();
         self.setup_scroll_controller();
     }
 
@@ -74,24 +73,6 @@ impl PlayListLyricsPage {
             glib::Propagation::Proceed
         });
         scroll_win.add_controller(scroll_controller);
-    }
-
-    fn update_font_size(&self) {
-        let imp = self.imp();
-        let lyrics_text_view = imp.lyrics_text_view.get();
-        let pango_context = lyrics_text_view.pango_context();
-        let font_description = pango_context
-            .font_description()
-            .expect("expect font description");
-        let font_size = font_description.size();
-
-        let font_size_in_pixels = if font_description.is_size_absolute() {
-            font_size as f64 / pango::SCALE as f64
-        } else {
-            font_size as f64 / pango::SCALE as f64
-        };
-
-        imp.font_size.replace(font_size_in_pixels);
     }
 
     pub fn update_playlist(&self, sis: &[SongInfo], current_song: SongInfo, likes: &[bool]) {
@@ -214,7 +195,6 @@ mod imp {
         pub buffer: TemplateChild<TextBuffer>,
         #[template_child]
         pub highlight_text_tag: TemplateChild<TextTag>,
-        pub(crate) font_size: Cell<f64>,
         pub(crate) scrolled: Arc<Mutex<usize>>,
         pub playlist: Rc<RefCell<Vec<SongInfo>>>,
         pub sender: OnceCell<Sender<Action>>,

--- a/src/gui/playlist_lyrics.rs
+++ b/src/gui/playlist_lyrics.rs
@@ -142,7 +142,9 @@ impl PlayListLyricsPage {
             if (time >= lyr[0].0 && time < lyr[1].0)
                 || lyr[0].0 == lyr[1].0 && time >= lyr[0].0 && time < lyr[2].0
             {
-                playing_index = i;
+                if playing_index == 0 {
+                    playing_index = i;
+                }
                 buffer.insert_markup(
                     &mut iter,
                     &format!(

--- a/src/window.rs
+++ b/src/window.rs
@@ -709,11 +709,26 @@ impl NeteaseCloudMusicGtk4Window {
         self.page_new(page, &gettext("Play List&Lyrics"));
     }
 
-    pub fn update_lyrics(&self, lrc: Vec<(u64, String)>, time: u64) {
+    /// 更新歌词内容，不调整位置
+    pub fn update_lyrics(&self, lrc: Vec<(u64, String)>) {
+        let imp = self.imp();
+        let page = imp.playlist_lyrics_page.get().unwrap();
+        page.update_lyrics(lrc);
+    }
+
+    /// 强行更新歌词区文字，用于显示歌词加载提示
+    pub fn update_lyrics_text(&self, text: &str) {
+        let imp = self.imp();
+        let page = imp.playlist_lyrics_page.get().unwrap();
+        page.update_lyrics_text(text);
+    }
+
+    // 更新歌词高亮位置
+    pub fn update_lyrics_timestamp(&self, time: u64) {
         let imp = self.imp();
         let page = imp.playlist_lyrics_page.get().unwrap();
         if self.page_cur_playlist_lyrics_page() {
-            page.update_lyrics(lrc, time);
+            page.update_lyrics_highlight(time);
         }
     }
 


### PR DESCRIPTION
* 准确的行高计算似乎并不容易（不太确定其它环境的情况，不过在我这里的 Arch Linux + KDE 工作得不好，计算结果会过大以至于把本应居中的文字推到中下的位置，甚至推出可见区域），因此考虑使用 GTK 的 [`TextView.scroll_to_mark`](https://docs.gtk.org/gtk4/method.TextView.scroll_to_mark.html) 进行居中
* 为了使 `scroll_to_mark` 中检测区域在屏幕上可见性的逻辑正常工作，把 `AdwClamp` 放到了外面（它似乎会使 `GtkTextView` 以为整个 view 都是可见的，从而使 `scroll_to_mark` 无法工作）
* 在每次高亮行变化，给 buffer 重新设置文字的时候，scroll 偏移会重置。所以换用了 GTK 的 [`TextTag`](https://docs.gtk.org/gtk4/class.TextTag.html) 来做高亮，而不是清空再重设 buffer 内的文字内容