### PR TITLE
为持久化音量增加了debounce功能 #275

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -53,6 +53,7 @@ pub enum Action {
     PlayStart(SongInfo),
     AddPlayList(Vec<SongInfo>),
     PlayListStart,
+    PersistVolume(f64),
 
     // login
     CheckLogin(UserMenuChild, CookieJar),
@@ -755,6 +756,9 @@ impl NeteaseCloudMusicGtk4Application {
                         }
                     }
                 });
+            }
+            Action::PersistVolume(value) => {
+                window.persist_volume(value);
             }
             Action::ToAlbumPage(songlist) => {
                 let page = window.init_songlist_page(&songlist, true);

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod gui;
 mod model;
 mod ncmapi;
 mod path;
+mod utils;
 mod window;
 
 use self::application::NeteaseCloudMusicGtk4Application;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,34 @@
+use glib::{timeout_add_seconds, SourceId};
+use gtk::glib;
+use std::sync::{Arc, Mutex};
+#[derive(Debug)]
+pub struct Debounce {
+    timer_id: Arc<Mutex<Option<SourceId>>>,
+}
+impl Debounce {
+    pub fn new() -> Self {
+        Self {
+            timer_id: Arc::new(Mutex::new(None)),
+        }
+    }
+    pub fn debounce<F>(&self, delay: u32, callback: F)
+    where
+        F: Fn() + 'static + Send,
+    {
+        let timer_id_clone = self.timer_id.clone();
+
+        if let Some(source_id) = timer_id_clone.lock().unwrap().take() {
+            source_id.remove();
+        }
+
+        let timer_id_closure = timer_id_clone.clone();
+        let new_timer_id = timeout_add_seconds(delay, move || {
+            callback();
+            timer_id_closure.lock().unwrap().take();
+            glib::ControlFlow::Break
+        });
+
+        let mut guard = timer_id_clone.lock().unwrap();
+        *guard = Some(new_timer_id);
+    }
+}

--- a/src/window.rs
+++ b/src/window.rs
@@ -616,6 +616,10 @@ impl NeteaseCloudMusicGtk4Window {
         }
         None
     }
+    pub fn persist_volume(&self,value: f64) {
+        let imp = self.imp();
+        imp.player_controls.persist_volume(value);
+    }
     pub fn page_cur_playlist_lyrics_page(&self) -> bool {
         let imp = self.imp();
         let page = imp.playlist_lyrics_page.get().unwrap();


### PR DESCRIPTION
为解决#275的问题，在`PlayerControls::set_volume`方法中添加了持久化音量的逻辑。 由于音量设置操作频率很高，不能每次设置音量都持久化到本地，于是新建了一个结构`utils::Debounce`用来提供debounce功能。
之所以把Debounce结构放在新建的`utils`文件中，是因为debounce的泛用性很强，可以用在很多其他操作频率高的逻辑中，比如`commit 68e3834`中的滚动逻辑。

效果演示：
![volume_control_debounce](https://github.com/user-attachments/assets/995ebfa4-e5ad-4b17-85c2-a615b4edcf07)

