### PR TITLE
lock gettext-rs version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "2.4.1"
 edition = "2021"
 
 [dependencies]
-gettext-rs = { version = "~0.7", features = ["gettext-system"] }
+gettext-rs = { version = "=0.7.0", features = ["gettext-system"] }
 gtk = { version = "~0.8", package = "gtk4" }
 once_cell = "~1.19"
 qrcode-generator = "~4.1"


### PR DESCRIPTION
gettext-rs 0.7.1 已经删除 `gettext!` macro:

https://github.com/gettext-rs/gettext-rs/commit/ec1aad1cbd167f56e6915c379c59d199a54c2758

如果不打算替换代码中的 macro，请合并。