### PR TITLE
add per-song playback quality selector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,7 @@ gettext-rs = { version = "~0.7", features = ["gettext-system"] }
 gtk = { version = "~0.11", package = "gtk4" }
 once_cell = "~1.21"
 qrcode-generator = "~5.0"
-# ncm-api = { git = "https://github.com/gmg137/netease-cloud-music-api.git", branch = "dev", package = "netease-cloud-music-api" }
-ncm-api = { git = "https://gitee.com/gmg137/netease-cloud-music-api.git", tag = "1.5.2", package = "netease-cloud-music-api" }
+ncm-api = { git = "https://github.com/zjy-dev/netease-cloud-music-api.git", branch = "feature/quality-level-api", package = "netease-cloud-music-api" }
 anyhow = "~1.0"
 gstreamer = "~0.25"
 gstreamer-play = "~0.25"

--- a/data/gtk/player-controls.ui
+++ b/data/gtk/player-controls.ui
@@ -175,6 +175,22 @@
                     </object>
                 </child>
                 <child>
+                    <object class="GtkMenuButton" id="quality_menu_button">
+                        <property name="focusable">False</property>
+                        <property name="receives_default">true</property>
+                        <property name="popover">quality_popover</property>
+                        <property name="tooltip-text" translatable="yes">Playback Quality</property>
+                        <child>
+                            <object class="GtkLabel" id="quality_label">
+                                <property name="label">Auto</property>
+                            </object>
+                        </child>
+                        <style>
+                            <class name="flat" />
+                        </style>
+                    </object>
+                </child>
+                <child>
                     <object class="GtkMenuButton" id="repeat_menu_button">
                         <property name="focusable">False</property>
                         <property name="receives_default">true</property>
@@ -262,6 +278,30 @@
                         <property name="label" translatable="yes">Shuffle</property>
                         <property name="group">none</property>
                         <signal name="toggled" handler="repeat_shuffle_cb" swapped="true" />
+                    </object>
+                </child>
+            </object>
+        </child>
+    </object>
+    <object class="GtkPopover" id="quality_popover">
+        <child>
+            <object class="GtkBox" id="quality_box">
+                <property name="orientation">vertical</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
+                <property name="margin-start">6</property>
+                <property name="margin-end">6</property>
+                <property name="spacing">6</property>
+                <child>
+                    <object class="GtkLabel" id="quality_status_label">
+                        <property name="halign">start</property>
+                        <property name="label">Checking...</property>
+                    </object>
+                </child>
+                <child>
+                    <object class="GtkBox" id="quality_options_box">
+                        <property name="orientation">vertical</property>
+                        <property name="spacing">3</property>
                     </object>
                 </child>
             </object>

--- a/data/gtk/preferences.ui
+++ b/data/gtk/preferences.ui
@@ -90,11 +90,14 @@
                                 <property name="model">
                                     <object class="GtkStringList">
                                         <items>
-                                            <item>128k</item>
-                                            <item>192k</item>
-                                            <item>320k</item>
-                                            <item>SQ</item>
-                                            <item>HR</item>
+                                            <item>Standard (标准)</item>
+                                            <item>Higher (较高)</item>
+                                            <item>Extreme (极高)</item>
+                                            <item>Lossless SQ (无损)</item>
+                                            <item>Hi-Res HR (高解析)</item>
+                                            <item>Surround SA (高清臻音)</item>
+                                            <item>Audio Vivid (臻音全景声)</item>
+                                            <item>Master (超清母带)</item>
                                         </items>
                                     </object>
                                 </property>

--- a/src/application.rs
+++ b/src/application.rs
@@ -7,7 +7,7 @@ use gtk::{gio, glib, prelude::*};
 use log::*;
 use ncm_api::{
     AlbumDetailDynamic, BannersInfo, CookieJar, LoginInfo, PlayListDetailDynamic, SingerInfo,
-    SongInfo, SongList, TargetType, TopList,
+    SongInfo, SongList, SongQuality, TargetType, TopList,
 };
 use once_cell::sync::OnceCell;
 use std::{cell::RefCell, fs, path::PathBuf, sync::Arc, time::Duration};
@@ -56,6 +56,8 @@ pub enum Action {
     AddPlayList(Vec<SongInfo>, bool),
     PlayListStart,
     PersistVolume(f64),
+    LoadSongQualities(SongInfo),
+    SetSongQuality(SongInfo, SongQuality),
     GetSongUrl(SongInfo),
     SetSongUrl(SongInfo),
 
@@ -670,7 +672,11 @@ impl NeteaseCloudMusicGtk4Application {
             }
             Action::Play(song_info) => {
                 let sender = imp.sender.clone();
-                let music_rate = window.settings().uint("music-rate");
+                let music_rate = song_info
+                    .quality
+                    .selected
+                    .map(NcmClient::get_quality_index)
+                    .unwrap_or_else(|| window.settings().uint("music-rate"));
                 let path = crate::path::get_music_cache_path(song_info.id, music_rate);
 
                 if !path.exists() {
@@ -681,10 +687,15 @@ impl NeteaseCloudMusicGtk4Application {
                             {
                                 debug!("获取歌曲播放链接: {:?}", song_url);
                                 if let Some(song_url) = song_url.first() {
-                                    let song_info = SongInfo {
-                                        song_url: song_url.url.to_owned(),
-                                        ..song_info
-                                    };
+                                    let mut song_info = song_info;
+                                    song_info.song_url = song_url.url.to_owned();
+                                    song_info.quality.actual = Some(song_url.quality);
+                                    if !song_info.quality.available.contains(&song_url.quality) {
+                                        song_info.quality.available.push(song_url.quality);
+                                    }
+                                    if song_info.quality.selected.is_none() {
+                                        song_info.quality.selected = Some(song_url.quality);
+                                    }
                                     sender.send(Action::PlayStart(song_info)).await.unwrap();
                                 } else {
                                     error!("获取歌曲播放链接失败: {:?}", &[song_info.id]);
@@ -733,6 +744,61 @@ impl NeteaseCloudMusicGtk4Application {
                 debug!("播放歌曲: {:?}", song_info);
                 window.play(song_info);
             }
+            Action::LoadSongQualities(song_info) => {
+                let sender = imp.sender.clone();
+                let default_quality = window.settings().uint("music-rate");
+                MAINCONTEXT.spawn_local_with_priority(Priority::DEFAULT_IDLE, async move {
+                    let mut candidates = song_info.quality.available.clone();
+                    if candidates.is_empty() {
+                        candidates = ncm_api::SongQuality::all().to_vec();
+                    }
+
+                    let mut available = Vec::new();
+                    for quality in candidates {
+                        let index = NcmClient::get_quality_index(quality);
+                        if let Ok(song_url) = ncmapi.songs_url(&[song_info.id], index).await {
+                            if song_url.first().is_some() {
+                                available.push(quality);
+                            }
+                        }
+                    }
+
+                    let mut song_info = song_info;
+                    song_info.quality.available = if available.is_empty() {
+                        vec![NcmClient::get_quality(default_quality)]
+                    } else {
+                        available
+                    };
+                    if song_info.quality.selected.is_none() {
+                        let default_quality = NcmClient::get_quality(default_quality);
+                        let selected = if song_info.quality.available.contains(&default_quality) {
+                            default_quality
+                        } else {
+                            *song_info.quality.available.first().unwrap()
+                        };
+                        song_info.quality.selected = Some(selected);
+                    }
+                    sender.send(Action::SetSongUrl(song_info)).await.unwrap();
+                });
+            }
+            Action::SetSongQuality(song_info, quality) => {
+                let sender = imp.sender.clone();
+                let s = quality.display_label().to_string();
+                window.settings().set_uint("music-rate", NcmClient::get_quality_index(quality)).unwrap();
+                MAINCONTEXT.spawn_local_with_priority(Priority::DEFAULT_IDLE, async move {
+                    let mut song_info = song_info;
+                    song_info.quality.selected = Some(quality);
+                    song_info.song_url.clear();
+                    sender
+                        .send(Action::AddToast(gettext_f(
+                            "Switched playback quality to [{quality}]",
+                            &[("quality", &s)],
+                        )))
+                        .await
+                        .unwrap();
+                    sender.send(Action::Play(song_info)).await.unwrap();
+                });
+            }
             Action::ToSongListPage(songlist) => {
                 let page = window.init_songlist_page(&songlist, false);
                 window.page_new(&page, &songlist.name, "ToSongListPage");
@@ -770,7 +836,11 @@ impl NeteaseCloudMusicGtk4Application {
             }
             Action::GetSongUrl(song_info) => {
                 let sender = imp.sender.clone();
-                let music_rate = window.settings().uint("music-rate");
+                let music_rate = song_info
+                    .quality
+                    .selected
+                    .map(NcmClient::get_quality_index)
+                    .unwrap_or_else(|| window.settings().uint("music-rate"));
                 let path = crate::path::get_music_cache_path(song_info.id, music_rate);
 
                 if !path.exists() {
@@ -778,10 +848,15 @@ impl NeteaseCloudMusicGtk4Application {
                         if let Ok(song_url) = ncmapi.songs_url(&[song_info.id], music_rate).await {
                             debug!("获取歌曲播放链接: {:?}", song_url);
                             if let Some(song_url) = song_url.first() {
-                                let song_info = SongInfo {
-                                    song_url: song_url.url.to_owned(),
-                                    ..song_info
-                                };
+                                let mut song_info = song_info;
+                                song_info.song_url = song_url.url.to_owned();
+                                song_info.quality.actual = Some(song_url.quality);
+                                if !song_info.quality.available.contains(&song_url.quality) {
+                                    song_info.quality.available.push(song_url.quality);
+                                }
+                                if song_info.quality.selected.is_none() {
+                                    song_info.quality.selected = Some(song_url.quality);
+                                }
                                 sender.send(Action::SetSongUrl(song_info)).await.unwrap();
                             }
                         }

--- a/src/audio/playlist.rs
+++ b/src/audio/playlist.rs
@@ -136,10 +136,12 @@ impl PlayList {
     pub fn set_song_url(&mut self, si: SongInfo) {
         if let Some(si_old) = self.list.iter_mut().find(|s| s.id == si.id) {
             si_old.song_url = si.song_url.clone();
+            si_old.quality = si.quality.clone();
         }
         if let LoopsState::Shuffle = self.loops {
             if let Some(si_old) = self.shuffle.iter_mut().find(|s| s.id == si.id) {
                 si_old.song_url = si.song_url;
+                si_old.quality = si.quality;
             }
         }
     }

--- a/src/gui/player_controls.rs
+++ b/src/gui/player_controls.rs
@@ -15,7 +15,7 @@ use gstreamer_play::{prelude::ElementExt, *};
 use gtk::{glib, prelude::*, subclass::prelude::*, CompositeTemplate, GestureClick, *};
 use log::*;
 use mpris_server::PlaybackStatus;
-use ncm_api::{SongInfo, SongList};
+use ncm_api::{SongInfo, SongList, SongQuality};
 use once_cell::sync::*;
 
 use crate::{application::Action, audio::*, model::ImageDownloadImpl, path::CACHE, utils::*};
@@ -145,7 +145,15 @@ impl PlayerControls {
         player.set_volume(self.property("volume"));
         player.play();
 
-        self.init_play_info(song_info);
+        let should_load_qualities = song_info.quality.available.is_empty();
+        self.init_play_info(song_info.clone());
+        if should_load_qualities {
+            imp.sender
+                .get()
+                .unwrap()
+                .send_blocking(Action::LoadSongQualities(song_info))
+                .unwrap();
+        }
     }
 
     pub fn next_song(&self) {
@@ -182,6 +190,8 @@ impl PlayerControls {
 
         let artist_label = imp.artist_label.get();
         artist_label.set_label(&song_info.singer);
+
+        self.update_quality_ui(&song_info);
 
         let volume = self.property("volume");
         if let Some(mpris) = imp.mpris.get() {
@@ -533,7 +543,64 @@ impl PlayerControls {
 
     pub fn set_song_url(&self, si: SongInfo) {
         if let Ok(mut playlist) = self.imp().playlist.lock() {
-            playlist.set_song_url(si);
+            playlist.set_song_url(si.clone());
+        }
+        if let Some(current) = self.get_current_song() {
+            if current.id == si.id {
+                self.update_quality_ui(&si);
+            }
+        }
+    }
+
+    fn update_quality_ui(&self, song_info: &SongInfo) {
+        let imp = self.imp();
+        let quality_label = imp.quality_label.get();
+        let quality_status_label = imp.quality_status_label.get();
+        let quality_options_box = imp.quality_options_box.get();
+
+        let current = song_info
+            .quality
+            .actual
+            .or(song_info.quality.selected)
+            .map(crate::utils::quality_label)
+            .unwrap_or("Checking...");
+        quality_label.set_label(current);
+
+        let status = if song_info.quality.available.is_empty() {
+            "Checking available qualities...".to_string()
+        } else {
+            let available = song_info
+                .quality
+                .available
+                .iter()
+                .map(|quality| crate::utils::quality_label(*quality))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("Available: {available}")
+        };
+        quality_status_label.set_label(&status);
+
+        while let Some(child) = quality_options_box.last_child() {
+            quality_options_box.remove(&child);
+        }
+
+        let sender = imp.sender.get().unwrap().clone();
+        for quality in SongQuality::all() {
+            let button = CheckButton::with_label(crate::utils::quality_label(*quality));
+            button.set_halign(Align::Start);
+            let available = song_info.quality.available.contains(quality);
+            button.set_sensitive(available);
+            button.set_active(song_info.quality.selected == Some(*quality));
+            let sender = sender.clone();
+            let song_info = song_info.clone();
+            button.connect_toggled(move |button| {
+                if button.is_active() && button.is_sensitive() {
+                    sender
+                        .send_blocking(Action::SetSongQuality(song_info.clone(), *quality))
+                        .unwrap();
+                }
+            });
+            quality_options_box.append(&button);
         }
     }
 
@@ -817,6 +884,14 @@ mod imp {
         pub duration_label: TemplateChild<Label>,
         #[template_child]
         pub volume_button: TemplateChild<VolumeButton>,
+        #[template_child]
+        pub quality_menu_button: TemplateChild<MenuButton>,
+        #[template_child]
+        pub quality_label: TemplateChild<Label>,
+        #[template_child]
+        pub quality_status_label: TemplateChild<Label>,
+        #[template_child]
+        pub quality_options_box: TemplateChild<Box>,
 
         #[template_child]
         pub repeat_menu_button: TemplateChild<MenuButton>,
@@ -1041,17 +1116,7 @@ mod imp {
             if let Ok(playlist) = self.playlist.lock() {
                 let current_song = playlist
                     .current_song()
-                    .unwrap_or(&SongInfo {
-                        id: 0,
-                        name: String::new(),
-                        singer: String::new(),
-                        album: String::new(),
-                        album_id: 0,
-                        pic_url: String::new(),
-                        duration: 0,
-                        song_url: String::new(),
-                        copyright: ncm_api::SongCopyright::Unknown,
-                    })
+                    .unwrap_or(&crate::utils::empty_song_info())
                     .to_owned();
                 let sender = self.sender.get().unwrap().clone();
                 sender

--- a/src/ncmapi.rs
+++ b/src/ncmapi.rs
@@ -5,7 +5,7 @@
 //
 use anyhow::Result;
 use cookie_store::{CookieStore, serde};
-use ncm_api::{CookieBuilder, CookieJar, MusicApi, SongInfo, SongUrl};
+use ncm_api::{CookieBuilder, CookieJar, MusicApi, SongInfo, SongQuality, SongUrl};
 
 use crate::path::{CACHE, LYRICS};
 use log::{debug, error};
@@ -58,7 +58,37 @@ impl NcmClient {
             2 => 320000,
             3 => 999000,
             4 => 1900000,
+            5 => 804505,
+            6 => 2695684,
+            7 => 4532511,
             _ => 320000,
+        }
+    }
+
+    pub fn get_quality(item: u32) -> SongQuality {
+        match item {
+            0 => SongQuality::Standard,
+            1 => SongQuality::Higher,
+            2 => SongQuality::Extreme,
+            3 => SongQuality::Lossless,
+            4 => SongQuality::HiRes,
+            5 => SongQuality::Surround,
+            6 => SongQuality::AudioVivid,
+            7 => SongQuality::Master,
+            _ => SongQuality::Extreme,
+        }
+    }
+
+    pub fn get_quality_index(quality: SongQuality) -> u32 {
+        match quality {
+            SongQuality::Standard => 0,
+            SongQuality::Higher => 1,
+            SongQuality::Extreme => 2,
+            SongQuality::Lossless => 3,
+            SongQuality::HiRes => 4,
+            SongQuality::Surround => 5,
+            SongQuality::AudioVivid => 6,
+            SongQuality::Master => 7,
         }
     }
 
@@ -161,9 +191,7 @@ impl NcmClient {
     }
 
     pub async fn songs_url(&self, ids: &[u64], rate: u32) -> Result<Vec<SongUrl>> {
-        self.client
-            .songs_url(ids, &Self::get_api_rate(rate).to_string())
-            .await
+        self.client.songs_url_v1(ids, Self::get_quality(rate)).await
     }
 
     pub async fn get_lyrics(&self, si: SongInfo) -> Result<Vec<(u64, String)>> {

--- a/src/path.rs
+++ b/src/path.rs
@@ -58,6 +58,9 @@ pub fn get_music_cache_path(id: u64, rate: u32) -> PathBuf {
         2 => 320000,
         3 => 999000,
         4 => 1900000,
+        5 => 804505,
+        6 => 2695684,
+        7 => 4532511,
         _ => 320000,
     };
     CACHE.join(format!("music_{}_{}", id, rate))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,7 @@
 use gettextrs::gettext;
 use glib::{timeout_add_seconds, SourceId};
 use gtk::glib;
+use ncm_api::{SongCopyright, SongInfo, SongQuality, SongQualityState};
 use std::sync::{Arc, Mutex};
 
 /// Like `gettext`, but replaces named variables with the given dictionary.
@@ -63,5 +64,33 @@ impl Debounce {
 impl Default for Debounce {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+pub fn quality_label(quality: SongQuality) -> &'static str {
+    match quality {
+        SongQuality::Standard => "Standard",
+        SongQuality::Higher => "Higher",
+        SongQuality::Extreme => "Extreme",
+        SongQuality::Lossless => "Lossless SQ",
+        SongQuality::HiRes => "Hi-Res HR",
+        SongQuality::Surround => "Surround SA",
+        SongQuality::AudioVivid => "Audio Vivid",
+        SongQuality::Master => "Master",
+    }
+}
+
+pub fn empty_song_info() -> SongInfo {
+    SongInfo {
+        id: 0,
+        name: String::new(),
+        singer: String::new(),
+        album: String::new(),
+        album_id: 0,
+        pic_url: String::new(),
+        duration: 0,
+        song_url: String::new(),
+        quality: SongQualityState::default(),
+        copyright: SongCopyright::Unknown,
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -463,17 +463,7 @@ impl NeteaseCloudMusicGtk4Window {
         player_controls.remove_song(song_info);
 
         let sis = player_controls.get_list();
-        let si = player_controls.get_current_song().unwrap_or(SongInfo {
-            id: 0,
-            name: String::new(),
-            singer: String::new(),
-            album: String::new(),
-            album_id: 0,
-            pic_url: String::new(),
-            duration: 0,
-            song_url: String::new(),
-            copyright: ncm_api::SongCopyright::Unknown,
-        });
+        let si = player_controls.get_current_song().unwrap_or(crate::utils::empty_song_info());
 
         self.init_playlist_lyrics_page(sis, si.to_owned());
 


### PR DESCRIPTION
## Summary
- add a playback-bar quality button with per-song available quality options
- switch playback flow to prefer selected song quality and persist it as the default for later songs
- integrate the client with the new level-based API branch for per-song quality-aware playback

## Dependency
- depends on the API changes proposed in PR #18 of gmg137/netease-cloud-music-api

## Notes
- this keeps Preferences as the default quality fallback, while moving the primary quality interaction into the playback bar