### PR TITLE
修复 gtk4 0.11 API 变更导致的编译失败

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 gettext-rs = { version = "~0.7", features = ["gettext-system"] }
-gtk = { version = "~0.11", package = "gtk4" }
+gtk = { version = "~0.11", package = "gtk4", features = ["v4_10"] }
 once_cell = "~1.21"
 qrcode-generator = "~5.0"
 # ncm-api = { git = "https://github.com/gmg137/netease-cloud-music-api.git", branch = "dev", package = "netease-cloud-music-api" }

--- a/src/application.rs
+++ b/src/application.rs
@@ -197,7 +197,7 @@ mod imp {
                 .unwrap();
 
             if let Some(weak_window) = self.window.get() {
-                weak_window.upgrade().unwrap().present();
+                gtk::prelude::GtkWindowExt::present(&weak_window.upgrade().unwrap());
                 return;
             }
 
@@ -220,7 +220,7 @@ mod imp {
             );
 
             // Ask the window manager/compositor to present the window
-            window.present();
+            gtk::prelude::GtkWindowExt::present(&window);
         }
     }
 
@@ -246,7 +246,7 @@ impl NeteaseCloudMusicGtk4Application {
         let imp = self.imp();
         let window = NeteaseCloudMusicGtk4Window::new(&self.clone(), imp.sender.clone());
 
-        window.present();
+        gtk::prelude::GtkWindowExt::present(&window);
         window
     }
 
@@ -1350,7 +1350,7 @@ impl NeteaseCloudMusicGtk4Application {
                 window.update_tray_song_title(title, artist, album_id);
             }
             Action::ShowMainWindow => {
-                window.present();
+                gtk::prelude::GtkWindowExt::present(&window);
             }
             Action::ShowPlayerBar => {
                 window.show_player_bar();
@@ -1399,7 +1399,7 @@ impl NeteaseCloudMusicGtk4Application {
         let (size, unit) = crate::path::get_cache_size();
         preferences.set_cache_size_label(size, unit);
 
-        preferences.present(Some(&window));
+        AdwDialogExt::present(&preferences, Some(&window));
     }
 
     fn show_about(&self) {

--- a/src/gui/player_controls.rs
+++ b/src/gui/player_controls.rs
@@ -929,7 +929,7 @@ impl PlayerControls {
     fn title_clicked_cb(&self) {
         if let Some(songinfo) = self.get_current_song() {
             let sender = self.imp().sender.get().unwrap().clone();
-            let clipboard = self.clipboard();
+            let clipboard = gtk::prelude::WidgetExt::clipboard(self);
             let share = gettext_f(
                 "https://music.163.com/song?id={id}\nsong:{name}\nsinger:{singer}",
                 &[

--- a/src/gui/songlist_grid_item.rs
+++ b/src/gui/songlist_grid_item.rs
@@ -134,7 +134,8 @@ impl SongListGridItem {
     fn setup_factory(grid: &GridView, pic_size: i32, show_author: bool) {
         let factory = SignalListItemFactory::new();
 
-        factory.connect_setup(move |_, list_item| {
+        factory.connect_setup(move |_, obj| {
+            let list_item = obj.downcast_ref::<ListItem>().unwrap();
             let (boxs, _, label, label_author) = Self::create(pic_size);
             if show_author {
                 label.set_lines(1);
@@ -142,7 +143,8 @@ impl SongListGridItem {
             label_author.set_visible(show_author);
             list_item.set_child(Some(&boxs));
         });
-        factory.connect_bind(move |_, list_item| {
+        factory.connect_bind(move |_, obj| {
+            let list_item = obj.downcast_ref::<ListItem>().unwrap();
             let songlist_object = list_item
                 .item()
                 .unwrap()

--- a/src/gui/songlist_row.rs
+++ b/src/gui/songlist_row.rs
@@ -44,7 +44,7 @@ impl SonglistRow {
         self.set_album(&si.album);
         self.set_duration(si.duration);
 
-        self.set_activatable(si.copyright.playable());
+        gtk::prelude::ListBoxRowExt::set_activatable(self, si.copyright.playable());
     }
 
     pub fn not_ignore_grey(&self) -> bool {
@@ -101,7 +101,7 @@ impl SonglistRow {
 impl SonglistRow {
     #[template_callback]
     fn on_click(&self) {
-        self.emit_activate();
+        gtk::prelude::ListBoxRowExt::emit_activate(self);
     }
 
     #[template_callback]

--- a/src/gui/songlist_view.rs
+++ b/src/gui/songlist_view.rs
@@ -73,17 +73,20 @@ impl SongListView {
             row.set_remove_button_visible(!no_act_remove);
 
             let si = si.clone();
-            row.connect_activate(clone!(
-                #[weak(rename_to = s)]
-                self,
-                move |row| {
-                    if row.is_activatable() || row.not_ignore_grey() {
-                        row.switch_image(true);
-                        sender.send_blocking(Action::AddPlay(si.clone())).unwrap();
-                        s.emit_row_activated(row);
+            gtk::prelude::ListBoxRowExt::connect_activate(
+                &row,
+                clone!(
+                    #[weak(rename_to = s)]
+                    self,
+                    move |row| {
+                        if row.is_activatable() || row.not_ignore_grey() {
+                            row.switch_image(true);
+                            sender.send_blocking(Action::AddPlay(si.clone())).unwrap();
+                            s.emit_row_activated(row);
+                        }
                     }
-                }
-            ));
+                ),
+            );
 
             settings
                 .bind("not-ignore-grey", &row, "not-ignore-grey")
@@ -127,7 +130,7 @@ impl SongListView {
         if let Some(row) = listbox.row_at_index(index) {
             let row = row.downcast::<SonglistRow>().unwrap();
             if do_active {
-                row.emit_activate();
+                gtk::prelude::ListBoxRowExt::emit_activate(&row);
             } else {
                 row.switch_image(true);
             }


### PR DESCRIPTION
## Summary
- 为 `gtk4` 启用 `v4_10` feature，修复 `Accessible` 因 feature gate 无法解析的问题
- 对 `present` / `clipboard` / `ListBoxRow` 相关调用使用 UFCS，消除 prelude trait 方法歧义
- 在 `SignalListItemFactory` 回调中将 `glib::Object` downcast 为 `ListItem`

## Test plan
- [x] 在 Fedora 44 + GTK 4.22 下 `meson setup _build && ninja -C _build` 编译通过
- [ ] 启动应用，确认窗口可正常显示
- [ ] 打开首选项对话框
- [ ] 点击播放栏标题，确认可复制歌曲信息到剪贴板
- [ ] 在歌单列表中点击歌曲行，确认可正常播放


Made with [Cursor](https://cursor.com)